### PR TITLE
Fix/jinja2 indentation

### DIFF
--- a/promptweaver/utils/string_utils.py
+++ b/promptweaver/utils/string_utils.py
@@ -30,3 +30,64 @@ def remove_blank_spaces(text: str) -> str:
         str: The input string with leading and trailing whitespace removed.
     """
     return re.sub(r"^\s+|\s+$", "", text)
+
+def add_indent_filters(template_lines: list[str]) -> str:
+    """
+    Processes a list of lines from a Jinja2 template and adds the `indent` filter
+    to any Jinja2 variables inside YAML block scalars to ensure proper indentation
+    when rendering variables containing special characters or newlines.
+
+    This function looks for lines within block scalars (indicated by `|` in YAML)
+    and adds the `indent` filter to Jinja2 variables found within those blocks.
+    
+    Args:
+        template_lines (list[str]): The lines of the Jinja2 template.
+
+    Returns:
+        str: The processed template as a single string with indent filters added to variables.
+    """
+    in_block_scalar = False
+    block_scalar_indent = None
+    output_lines = []
+    variable_pattern = re.compile(r'{{\s*(.*?)\s*}}')
+
+    for _, line in enumerate(template_lines):
+        # Get current indentation level
+        current_indent = len(line) - len(line.lstrip(' '))
+        stripped_line = line.strip()
+
+        # Check if line ends with '|' and not inside a block scalar
+        if stripped_line.endswith('|') and not in_block_scalar:
+            in_block_scalar = True
+            block_scalar_indent = current_indent
+            output_lines.append(line)
+            continue
+
+        if in_block_scalar:
+            # Check if we've exited the block scalar
+            if current_indent <= block_scalar_indent and stripped_line != '':
+                # Exited block scalar
+                in_block_scalar = False
+                block_scalar_indent = None
+                output_lines.append(line)
+                continue
+            else:
+                # We are inside the block scalar
+                # Check for Jinja2 variable
+                def repl(m):
+                    var_content = m.group(1)
+                    # Check if variable already has an indent filter
+                    if '| indent(' not in m.group(0):
+                        # Add indent filter with correct indentation
+                        return '{{ ' + var_content + ' | indent(' + str(current_indent) + ') }}'
+                    else:
+                        return m.group(0)
+                # Replace variables with indent filter
+                new_line = variable_pattern.sub(repl, line)
+                output_lines.append(new_line)
+                continue
+        else:
+            # Not inside block scalar
+            output_lines.append(line)
+
+    return ''.join(output_lines)

--- a/samples/01-hello-world-text.yml.j2
+++ b/samples/01-hello-world-text.yml.j2
@@ -13,4 +13,5 @@ variables:
     sample: Hi!
 # ---
 user:
-  - text: {{ user_message }}
+  - text: |
+      {{ user_message }}


### PR DESCRIPTION
Fixed handling of multiline Jinja2 variables and improved YAML parsing error handling. #16 

### Summary
This pull request addresses issues with rendering and parsing YAML templates that include Jinja2 variables containing multiline strings or special characters (e.g., `\n`,` \r`). Previously, these variables could cause invalid YAML due to improper indentation, leading to parsing errors. The following changes have been made:

**Improved Indentation Handling:**
- Implemented a function to automatically add the `indent` filter to Jinja2 variables inside YAML block scalars, ensuring proper indentation in the rendered output.

**Enhanced Error Handling:**
- Updated the `parse_rendered_yaml` method to provide detailed error messages when YAML parsing fails.
- Included context-specific information, such as line numbers and snippets of problematic content, to aid in debugging.
